### PR TITLE
Remove Claude extractor references from extraction pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Read PLAN.md for full architecture. We're building a research paper knowledge gr
 ## Phase-Specific Notes
 
 ### Phase 3 (Extraction)
-- Implement LLM adapter pattern (OpenAIExtractor, ClaudeExtractor base class)
+- Implement LLM adapter pattern (OpenAIExtractor base class for now)
 - Two-pass MANDATORY: LLM returns text, linker finds offsets
 - Fuzzy matching threshold: 0.90 (configurable in config.yaml)
 - Log rejected triples with reasons (for debugging)
@@ -67,6 +67,6 @@ Read PLAN.md for full architecture. We're building a research paper knowledge gr
 
 ## Current Phase
 [Update this as you progress]
-Phase: 1 - Parsing & Metadata
+Phase: 3 - Triplet Extraction
 Status: In progress
 Blockers: None

--- a/PLAN.md
+++ b/PLAN.md
@@ -221,11 +221,10 @@ For each triple from Pass A:
 
 **Start with:**
 - GPT-4o-mini (good offset reliability, fast)
-- OR Claude 3.5 Sonnet (excellent instruction following)
 
 **Build an adapter interface:**
 - Abstract class `LLMExtractor` with method `extract_triples(chunk, entities) -> List[RawTriple]`
-- Implementations: `OpenAIExtractor`, `ClaudeExtractor`, `LocalLLMExtractor`
+- Implementations: `OpenAIExtractor`, `LocalLLMExtractor`
 - Config flag to switch: `extraction.llm_provider: "openai"`
 - This allows zero-code swap to Llama-3.1-8B later
 
@@ -249,10 +248,9 @@ For each triple from Pass A:
 - Assert exact match on accepted triples after span linking
 
 **Offset reliability benchmark:**
-- Run same 50 chunks through GPT-4o-mini vs Claude Sonnet
+- Run 50 representative chunks through GPT-4o-mini
 - Measure: % triples that pass span validation
-- Choose model with ≥85% pass rate
-- If both fail, adjust fuzzy threshold or add better prompting
+- Target ≥85% pass rate (tune fuzzy threshold or prompts if below)
 
 **Load test:**
 - Process 200 chunks in <5 minutes (with batching)
@@ -1090,7 +1088,7 @@ Before declaring MVP complete:
 - NLP: spaCy (en_core_web_sm), scispaCy (en_core_sci_md) optional
 - Embeddings: E5-base via sentence-transformers
 - Similarity: FAISS (IndexFlatIP)
-- LLM: OpenAI GPT-4o-mini OR Anthropic Claude 3.5 Sonnet (adapter pattern)
+- LLM: OpenAI GPT-4o-mini (adapter pattern ready for future providers)
 - Graph DB: Neo4j
 - Task queue: (optional) Celery + Redis for post-MVP
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -45,6 +45,8 @@ class ExtractionConfig(_FrozenModel):
     chunk_size_tokens: int = Field(..., ge=1)
     chunk_overlap_tokens: int = Field(..., ge=0)
     use_entity_inventory: bool = False
+    llm_provider: str = Field(..., min_length=1)
+    fuzzy_match_threshold: float = Field(..., ge=0.0, le=1.0)
 
 
 class CanonicalizationConfig(_FrozenModel):

--- a/backend/app/extraction/__init__.py
+++ b/backend/app/extraction/__init__.py
@@ -1,5 +1,21 @@
 """Extraction utilities for SciNets backend."""
 
 from backend.app.extraction.entity_inventory import EntityInventoryBuilder
+from backend.app.extraction.triplet_extraction import (
+    LLMExtractor,
+    OpenAIExtractor,
+    RawLLMTriple,
+    TwoPassTripletExtractor,
+    normalize_relation,
+    spans_overlap,
+)
 
-__all__ = ["EntityInventoryBuilder"]
+__all__ = [
+    "EntityInventoryBuilder",
+    "LLMExtractor",
+    "OpenAIExtractor",
+    "RawLLMTriple",
+    "TwoPassTripletExtractor",
+    "normalize_relation",
+    "spans_overlap",
+]

--- a/backend/app/extraction/triplet_extraction.py
+++ b/backend/app/extraction/triplet_extraction.py
@@ -1,0 +1,332 @@
+"""Two-pass triplet extraction pipeline for Phase 3."""
+from __future__ import annotations
+
+import logging
+import math
+import re
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from typing import List, Optional, Sequence, Tuple
+
+from backend.app.config import AppConfig
+from backend.app.contracts import Evidence, ParsedElement, TextSpan, Triplet
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RawLLMTriple:
+    """Representation of a triple returned from the LLM pass."""
+
+    subject_text: str
+    relation_verbatim: str
+    object_text: str
+    supportive_sentence: str
+    confidence: float
+
+
+class LLMExtractor(ABC):
+    """Interface for LLM-backed triple extraction adapters."""
+
+    @abstractmethod
+    def extract_triples(
+        self,
+        element: ParsedElement,
+        candidate_entities: Optional[Sequence[str]],
+        max_triples: int,
+    ) -> Sequence[RawLLMTriple]:
+        """Extract raw triples for a parsed element.
+
+        Args:
+            element: Parsed element describing the chunk to analyze.
+            candidate_entities: Optional ordered list of candidate entity strings.
+            max_triples: Maximum number of triples to return.
+
+        Returns:
+            Sequence[RawLLMTriple]: Raw triples emitted by the language model.
+        """
+
+
+class OpenAIExtractor(LLMExtractor):
+    """Adapter placeholder for OpenAI-based extraction."""
+
+    def __init__(self, *_: object, **__: object) -> None:
+        """Initialize the extractor."""
+
+    def extract_triples(
+        self,
+        element: ParsedElement,
+        candidate_entities: Optional[Sequence[str]],
+        max_triples: int,
+    ) -> Sequence[RawLLMTriple]:
+        """Invoke the OpenAI API for extraction.
+
+        Args:
+            element: Parsed element describing the chunk to analyze.
+            candidate_entities: Optional ordered list of candidate entity strings.
+            max_triples: Maximum number of triples to return.
+
+        Returns:
+            Sequence[RawLLMTriple]: Raw triples emitted by the language model.
+
+        Raises:
+            NotImplementedError: Always raised until the adapter is implemented.
+        """
+
+        raise NotImplementedError("OpenAI extractor requires API integration")
+
+
+class TwoPassTripletExtractor:
+    """Perform two-pass extraction with deterministic span linking."""
+
+    def __init__(self, config: AppConfig, llm_extractor: LLMExtractor) -> None:
+        """Create a new extraction pipeline.
+
+        Args:
+            config: Parsed application configuration.
+            llm_extractor: Adapter responsible for producing raw triples.
+        """
+
+        self._config = config
+        self._llm_extractor = llm_extractor
+        self._threshold = config.extraction.fuzzy_match_threshold
+
+    def extract_from_element(
+        self,
+        element: ParsedElement,
+        candidate_entities: Optional[Sequence[str]],
+    ) -> List[Triplet]:
+        """Extract validated triples from the provided element.
+
+        Args:
+            element: Parsed element to extract triples from.
+            candidate_entities: Optional ordered list of suggested entity mentions.
+
+        Returns:
+            List[Triplet]: Triples that passed span validation and normalization.
+        """
+
+        max_triples = self._compute_max_triples(element.content)
+        raw_triples = self._llm_extractor.extract_triples(
+            element=element,
+            candidate_entities=candidate_entities,
+            max_triples=max_triples,
+        )
+        accepted: List[Triplet] = []
+        for raw in raw_triples:
+            try:
+                normalized_relation, swap = normalize_relation(raw.relation_verbatim)
+            except ValueError:
+                LOGGER.info("Dropping triple with unmapped relation: %s", raw.relation_verbatim)
+                continue
+            subject_text = raw.subject_text.strip()
+            object_text = raw.object_text.strip()
+            sentence_text = raw.supportive_sentence.strip()
+            if not subject_text or not object_text or not sentence_text:
+                LOGGER.info("Dropping triple with empty fields: %s", raw)
+                continue
+            if not (0.0 <= raw.confidence <= 1.0):
+                LOGGER.info("Dropping triple with invalid confidence %.3f", raw.confidence)
+                continue
+            if swap:
+                subject_text, object_text = object_text, subject_text
+            subject_span = self._find_span(element.content, subject_text)
+            object_span = self._find_span(element.content, object_text)
+            sentence_span = self._find_span(element.content, sentence_text)
+            if not subject_span:
+                LOGGER.info("Dropping triple; subject span not found: %s", subject_text)
+                continue
+            if not object_span:
+                LOGGER.info("Dropping triple; object span not found: %s", object_text)
+                continue
+            if subject_span[0] < 0 or subject_span[1] > len(element.content):
+                LOGGER.info("Dropping triple; subject span out of bounds: %s", subject_span)
+                continue
+            if object_span[0] < 0 or object_span[1] > len(element.content):
+                LOGGER.info("Dropping triple; object span out of bounds: %s", object_span)
+                continue
+            if spans_overlap(subject_span, object_span):
+                LOGGER.info("Dropping triple; overlapping subject/object spans: %s", raw)
+                continue
+            if not sentence_span:
+                LOGGER.info("Dropping triple; sentence span not found: %s", sentence_text)
+                continue
+            if sentence_span[0] < 0 or sentence_span[1] > len(element.content):
+                LOGGER.info("Dropping triple; sentence span out of bounds: %s", sentence_span)
+                continue
+            evidence = Evidence(
+                element_id=element.element_id,
+                doc_id=element.doc_id,
+                text_span=TextSpan(start=sentence_span[0], end=sentence_span[1]),
+                full_sentence=element.content[sentence_span[0] : sentence_span[1]],
+            )
+            triplet = Triplet(
+                subject=subject_text,
+                predicate=normalized_relation,
+                object=object_text,
+                confidence=raw.confidence,
+                evidence=evidence,
+                pipeline_version=self._config.pipeline.version,
+            )
+            accepted.append(triplet)
+        return accepted
+
+    def _compute_max_triples(self, content: str) -> int:
+        """Compute the triple limit for an element based on token count.
+
+        Args:
+            content: Text content of the parsed element.
+
+        Returns:
+            int: Maximum number of triples allowed for the chunk.
+        """
+
+        tokens = re.findall(r"\w+", content)
+        token_count = len(tokens)
+        scaled = max(1, math.ceil(token_count / self._config.extraction.tokens_per_triple))
+        sentence_count = max(1, len(re.findall(r"[^.!?]+[.!?]", content)))
+        estimate = max(scaled, sentence_count)
+        return min(self._config.extraction.max_triples_per_chunk_base, estimate)
+
+    def _find_span(self, text: str, target: str) -> Optional[Tuple[int, int]]:
+        """Locate the character span of the target text within the source.
+
+        Args:
+            text: Source text to search within.
+            target: Target substring to locate.
+
+        Returns:
+            Optional[Tuple[int, int]]: Inclusive-exclusive span if found, otherwise None.
+        """
+
+        if not target:
+            return None
+        index = text.find(target)
+        if index != -1:
+            return index, index + len(target)
+        lower_index = text.lower().find(target.lower())
+        if lower_index != -1:
+            return lower_index, lower_index + len(target)
+        return self._fuzzy_find_span(text, target)
+
+    def _fuzzy_find_span(self, text: str, target: str) -> Optional[Tuple[int, int]]:
+        """Perform fuzzy matching to locate a target span.
+
+        Args:
+            text: Source text to search within.
+            target: Target substring to locate approximately.
+
+        Returns:
+            Optional[Tuple[int, int]]: Inclusive-exclusive span if a close match is found.
+        """
+
+        threshold = self._threshold
+        if threshold <= 0:
+            return None
+        normalized_target = target.strip()
+        if not normalized_target:
+            return None
+        span_length = len(normalized_target)
+        best_ratio = 0.0
+        best_span: Optional[Tuple[int, int]] = None
+        limit = len(text) - span_length
+        if limit < 0:
+            ratio = SequenceMatcher(None, text.lower(), normalized_target.lower()).ratio()
+            if ratio >= threshold:
+                return 0, len(text)
+            return None
+        for start in range(0, limit + 1):
+            candidate = text[start : start + span_length]
+            ratio = SequenceMatcher(None, candidate.lower(), normalized_target.lower()).ratio()
+            if ratio >= threshold and ratio > best_ratio:
+                best_ratio = ratio
+                best_span = (start, start + span_length)
+        return best_span
+
+
+def spans_overlap(first: Tuple[int, int], second: Tuple[int, int]) -> bool:
+    """Return whether two spans overlap.
+
+    Args:
+        first: First character span.
+        second: Second character span.
+
+    Returns:
+        bool: True if spans overlap, False otherwise.
+    """
+
+    return max(first[0], second[0]) < min(first[1], second[1])
+
+
+def normalize_relation(relation_text: str) -> Tuple[str, bool]:
+    """Normalize a relation phrase to the canonical predicate name.
+
+    Args:
+        relation_text: Relation phrase returned by the LLM.
+
+    Returns:
+        Tuple[str, bool]: Canonical predicate and whether subject/object should swap.
+
+    Raises:
+        ValueError: If the relation cannot be mapped to a canonical predicate.
+    """
+
+    cleaned = re.sub(r"[^a-z]+", " ", relation_text.lower()).strip()
+    cleaned = re.sub(r"\s+", " ", cleaned)
+    for phrase, normalized, swap in _RELATION_PATTERNS:
+        if phrase in cleaned:
+            return normalized, swap
+    raise ValueError(f"Unsupported relation phrase: {relation_text}")
+
+
+_RELATION_PATTERNS: List[Tuple[str, str, bool]] = sorted(
+    [
+        ("is used by", "uses", True),
+        ("was used by", "uses", True),
+        ("uses", "uses", False),
+        ("utilizes", "uses", False),
+        ("employs", "uses", False),
+        ("trained on", "trained-on", False),
+        ("is trained on", "trained-on", False),
+        ("was trained on", "trained-on", False),
+        ("evaluated on", "evaluated-on", False),
+        ("tested on", "evaluated-on", False),
+        ("assessed on", "evaluated-on", False),
+        ("compared to", "compared-to", False),
+        ("compared with", "compared-to", False),
+        ("outperforms", "outperforms", False),
+        ("performs better than", "outperforms", False),
+        ("increases", "increases", False),
+        ("improves", "increases", False),
+        ("boosts", "increases", False),
+        ("decreases", "decreases", False),
+        ("reduces", "decreases", False),
+        ("lowers", "decreases", False),
+        ("causes", "causes", False),
+        ("results in", "causes", False),
+        ("leads to", "causes", False),
+        ("correlates with", "correlates-with", False),
+        ("correlates to", "correlates-with", False),
+        ("associated with", "correlates-with", False),
+        ("defined as", "defined-as", False),
+        ("is defined as", "defined-as", False),
+        ("part of", "part-of", False),
+        ("component of", "part-of", False),
+        ("is a", "is-a", False),
+        ("is an", "is-a", False),
+    ],
+    key=lambda item: len(item[0]),
+    reverse=True,
+)
+
+
+__all__ = [
+    "RawLLMTriple",
+    "LLMExtractor",
+    "OpenAIExtractor",
+    "TwoPassTripletExtractor",
+    "normalize_relation",
+    "spans_overlap",
+]
+

--- a/config.yaml
+++ b/config.yaml
@@ -35,6 +35,8 @@ extraction:
   chunk_size_tokens: 512
   chunk_overlap_tokens: 50
   use_entity_inventory: false
+  llm_provider: "openai"
+  fuzzy_match_threshold: 0.9
 
 canonicalization:
   base_threshold: 0.86

--- a/tests/fixtures/golden/phase_3/sample_chunk.json
+++ b/tests/fixtures/golden/phase_3/sample_chunk.json
@@ -1,0 +1,68 @@
+{
+  "element": {
+    "doc_id": "doc-3",
+    "element_id": "doc-3:0",
+    "section": "Results",
+    "content": "The Reinforcement Learning agent uses the PPO algorithm to stabilize training. The Reinforcement Learning agent outperforms baseline methods on Atari games.",
+    "content_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "start_char": 0,
+    "end_char": 156
+  },
+  "candidate_entities": [
+    "Reinforcement Learning agent",
+    "PPO algorithm",
+    "baseline methods"
+  ],
+  "llm_response": {
+    "triples": [
+      {
+        "subject_text": "The Reinforcement Learning agent",
+        "relation_verbatim": "uses",
+        "object_text": "the PPO algorithm",
+        "supportive_sentence": "The Reinforcement Learning agent uses the PPO algorithm to stabilize training.",
+        "confidence": 0.95
+      },
+      {
+        "subject_text": "The Reinforcement Learning agent",
+        "relation_verbatim": "outperforms",
+        "object_text": "baseline methods",
+        "supportive_sentence": "The Reinforcement Learning agent outperforms baseline methods on Atari games.",
+        "confidence": 0.9
+      }
+    ]
+  },
+  "expected": [
+    {
+      "subject": "The Reinforcement Learning agent",
+      "predicate": "uses",
+      "object": "the PPO algorithm",
+      "confidence": 0.95,
+      "evidence": {
+        "element_id": "doc-3:0",
+        "text_span": {
+          "start": 0,
+          "end": 78
+        },
+        "doc_id": "doc-3",
+        "full_sentence": "The Reinforcement Learning agent uses the PPO algorithm to stabilize training."
+      },
+      "pipeline_version": "1.0.0"
+    },
+    {
+      "subject": "The Reinforcement Learning agent",
+      "predicate": "outperforms",
+      "object": "baseline methods",
+      "confidence": 0.9,
+      "evidence": {
+        "element_id": "doc-3:0",
+        "text_span": {
+          "start": 79,
+          "end": 156
+        },
+        "doc_id": "doc-3",
+        "full_sentence": "The Reinforcement Learning agent outperforms baseline methods on Atari games."
+      },
+      "pipeline_version": "1.0.0"
+    }
+  ]
+}

--- a/tests/phase_0/test_config.py
+++ b/tests/phase_0/test_config.py
@@ -12,6 +12,8 @@ def test_config_loads_expected_structure(tmp_path) -> None:
     assert config.parsing.section_fuzzy_threshold == 0.85
     assert "NeurIPS" in config.parsing.metadata_known_venues
     assert config.extraction.max_triples_per_chunk_base == 15
+    assert config.extraction.llm_provider == "openai"
+    assert config.extraction.fuzzy_match_threshold == 0.9
     assert config.canonicalization.base_threshold == 0.86
     assert config.canonicalization.polysemy_section_diversity == 3
     assert config.qa.entity_match_threshold == 0.83

--- a/tests/phase_3/__init__.py
+++ b/tests/phase_3/__init__.py
@@ -1,0 +1,2 @@
+"""Phase 3 test suite."""
+

--- a/tests/phase_3/test_triplet_extraction.py
+++ b/tests/phase_3/test_triplet_extraction.py
@@ -1,0 +1,149 @@
+"""Tests for the two-pass triplet extraction pipeline."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Sequence
+
+import pytest
+
+from backend.app.config import load_config
+from backend.app.contracts import ParsedElement
+from backend.app.extraction.triplet_extraction import (
+    LLMExtractor,
+    RawLLMTriple,
+    TwoPassTripletExtractor,
+    normalize_relation,
+)
+
+
+FIXTURES_DIR = Path(__file__).resolve().parents[2] / "tests" / "fixtures"
+GOLDEN_DIR = FIXTURES_DIR / "golden" / "phase_3"
+
+
+@pytest.fixture(name="config")
+def fixture_config():
+    """Load application configuration for extraction tests."""
+
+    return load_config()
+
+
+@dataclass(frozen=True)
+class _StubExtractor(LLMExtractor):
+    """LLM extractor that returns pre-seeded triples for tests."""
+
+    triples: Sequence[RawLLMTriple]
+
+    def extract_triples(
+        self,
+        element: ParsedElement,
+        candidate_entities: Optional[Sequence[str]],
+        max_triples: int,
+    ) -> Sequence[RawLLMTriple]:
+        """Return the configured triples regardless of inputs."""
+
+        return list(self.triples)[:max_triples]
+
+
+def _element_from_fixture(payload: dict) -> ParsedElement:
+    """Build a parsed element from a fixture payload."""
+
+    return ParsedElement(**payload)
+
+
+def _load_golden(name: str) -> dict:
+    """Load a golden fixture from disk."""
+
+    with (GOLDEN_DIR / f"{name}.json").open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def test_normalize_relation_rejects_unknown_relation() -> None:
+    """Unknown relation phrases should raise a validation error."""
+
+    with pytest.raises(ValueError):
+        normalize_relation("collaborates with")
+
+
+def test_triplet_with_missing_span_is_rejected(config) -> None:
+    """Triples without resolvable spans should be dropped."""
+
+    element = ParsedElement(
+        doc_id="doc-1",
+        element_id="doc-1:0",
+        section="Results",
+        content="Graph neural networks achieve strong accuracy.",
+        content_hash="a" * 64,
+        start_char=0,
+        end_char=44,
+    )
+    extractor = _StubExtractor(
+        triples=[
+            RawLLMTriple(
+                subject_text="Transformer",  # not present
+                relation_verbatim="uses",
+                object_text="attention",
+                supportive_sentence="Graph neural networks achieve strong accuracy.",
+                confidence=0.9,
+            )
+        ]
+    )
+    pipeline = TwoPassTripletExtractor(config=config, llm_extractor=extractor)
+
+    triples = pipeline.extract_from_element(element, candidate_entities=None)
+
+    assert triples == []
+
+
+def test_passive_voice_flips_subject_and_object(config) -> None:
+    """Passive voice relations should swap subject and object."""
+
+    content = "The dataset is used by the model to improve accuracy."
+    element = ParsedElement(
+        doc_id="doc-2",
+        element_id="doc-2:0",
+        section="Methods",
+        content=content,
+        content_hash="b" * 64,
+        start_char=0,
+        end_char=len(content),
+    )
+    extractor = _StubExtractor(
+        triples=[
+            RawLLMTriple(
+                subject_text="The dataset",
+                relation_verbatim="is used by",
+                object_text="the model",
+                supportive_sentence=content,
+                confidence=0.92,
+            )
+        ]
+    )
+    pipeline = TwoPassTripletExtractor(config=config, llm_extractor=extractor)
+
+    triples = pipeline.extract_from_element(element, candidate_entities=None)
+
+    assert len(triples) == 1
+    triple = triples[0]
+    assert triple.subject == "the model"
+    assert triple.object == "The dataset"
+    assert triple.predicate == "uses"
+
+
+def test_golden_triplet_extraction_matches_fixture(config) -> None:
+    """Two-pass extraction should reproduce the golden fixture output."""
+
+    fixture = _load_golden("sample_chunk")
+    element = _element_from_fixture(fixture["element"])
+    triples_payload = [
+        RawLLMTriple(**triple)
+        for triple in fixture["llm_response"]["triples"]
+    ]
+    extractor = _StubExtractor(triples=triples_payload)
+    pipeline = TwoPassTripletExtractor(config=config, llm_extractor=extractor)
+
+    extracted = pipeline.extract_from_element(element, candidate_entities=fixture.get("candidate_entities"))
+
+    assert [trip.model_dump() for trip in extracted] == fixture["expected"]
+


### PR DESCRIPTION
## Summary
- remove Claude extractor class and related exports so only the OpenAI adapter remains
- update contributor instructions and the execution plan to reflect the OpenAI-only strategy

## Testing
- pytest tests/phase_3/test_triplet_extraction.py::test_golden_triplet_extraction_matches_fixture -vv

------
https://chatgpt.com/codex/tasks/task_e_68e4a0f387fc8321a9a40c1287b5d4b7